### PR TITLE
[Refactor/#105] fix sub filter reset button

### DIFF
--- a/feature/place/src/main/java/com/teamsolply/solply/place/PlaceContract.kt
+++ b/feature/place/src/main/java/com/teamsolply/solply/place/PlaceContract.kt
@@ -52,6 +52,7 @@ sealed interface PlaceIntent : UiIntent {
 
     data object SubFilterChipClick : PlaceIntent
     data object SubFilterBottomSheetCompleteButtonClick : PlaceIntent
+    data object SubFilterBottomSheetResetButtonClick : PlaceIntent
     data object SubFilterBottomSheetDismiss : PlaceIntent
     data class SubFilterClick(
         val optionFilterId: Int,

--- a/feature/place/src/main/java/com/teamsolply/solply/place/PlaceScreen.kt
+++ b/feature/place/src/main/java/com/teamsolply/solply/place/PlaceScreen.kt
@@ -154,7 +154,7 @@ fun PlaceRoute(
                 onDismiss = {
                     viewModel.sendIntent(PlaceIntent.SubFilterBottomSheetDismiss)
                 },
-                onReset = { viewModel.sendIntent(PlaceIntent.SubFilterBottomSheetDismiss) },
+                onReset = { viewModel.sendIntent(PlaceIntent.SubFilterBottomSheetResetButtonClick) },
                 onDone = {
                     viewModel.sendIntent(PlaceIntent.SubFilterBottomSheetCompleteButtonClick)
                 }

--- a/feature/place/src/main/java/com/teamsolply/solply/place/PlaceViewModel.kt
+++ b/feature/place/src/main/java/com/teamsolply/solply/place/PlaceViewModel.kt
@@ -118,6 +118,13 @@ class PlaceViewModel @Inject constructor(
                 }
             }
 
+            is PlaceIntent.SubFilterBottomSheetResetButtonClick -> reduce {
+                copy(
+                    selectedOptionAFilter = persistentListOf(),
+                    selectedOptionBFilter = persistentListOf()
+                )
+            }
+
             PlaceIntent.SubFilterBottomSheetDismiss -> reduce {
                 copy(
                     selectedOptionAFilter = persistentListOf(),


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 서브 필터 바텀시트 초기화 버튼 수정

🌱 PR 포인트
-

## 📸 스크린샷
|스크린샷|
|:--:|
|파일첨부바람|
<!-- <img width="300" src="이미지 주소" /> -->
## 📮 관련 이슈
- Resolved: #이슈번호


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 서브 필터 바텀시트에서 리셋 버튼 클릭 시, 선택된 필터 옵션이 모두 초기화되는 기능이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->