### PR TITLE
[Hotfix] qa 실시간 수정

### DIFF
--- a/core/designsystem/src/main/java/com/teamsolply/solply/designsystem/component/chip/PlaceTag.kt
+++ b/core/designsystem/src/main/java/com/teamsolply/solply/designsystem/component/chip/PlaceTag.kt
@@ -21,7 +21,7 @@ fun PlaceTag(
         PlaceType.CAFE -> SolplyTheme.colors.red500
         PlaceType.FOOD -> SolplyTheme.colors.yellow500
         PlaceType.BOOKSTORE -> SolplyTheme.colors.purple600
-        PlaceType.WALKING -> SolplyTheme.colors.gray500
+        PlaceType.WALKING -> SolplyTheme.colors.green500
         PlaceType.SHOPPING -> SolplyTheme.colors.purple600
         PlaceType.UNIQUE_SPACE -> SolplyTheme.colors.green500
         PlaceType.ALL -> SolplyTheme.colors.white

--- a/core/designsystem/src/main/java/com/teamsolply/solply/designsystem/component/snackbar/SolplySnackBar.kt
+++ b/core/designsystem/src/main/java/com/teamsolply/solply/designsystem/component/snackbar/SolplySnackBar.kt
@@ -84,7 +84,7 @@ fun SolplyNavigateSnackBar(text: String, navigateToRoute: () -> Unit) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = 20.dp, vertical = 12.dp),
+                .padding(start = 20.dp, end = 12.dp, top = 12.dp, bottom = 12.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
@@ -98,7 +98,7 @@ fun SolplyNavigateSnackBar(text: String, navigateToRoute: () -> Unit) {
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(
-                    text = "코스 수정하기",
+                    text = "수정하기",
                     style = SolplyTheme.typography.body14M,
                     color = SolplyTheme.colors.purple400
                 )


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- 5시 QA 실시간 수정사항입니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 걷기 장소 태그의 텍스트 색상이 회색에서 초록색으로 변경되었습니다.
  * 스낵바의 좌우 여백이 비대칭(왼쪽 20dp, 오른쪽 12dp)으로 조정되었습니다.
  * 스낵바 내 버튼 텍스트가 "코스 수정하기"에서 "수정하기"로 간결하게 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->