### PR TITLE
[Feature/#136] onboarding bottom sheet

### DIFF
--- a/feature/course/src/main/java/com/teamsolply/solply/course/favoriteTown/FavoriteTownScreen.kt
+++ b/feature/course/src/main/java/com/teamsolply/solply/course/favoriteTown/FavoriteTownScreen.kt
@@ -1,7 +1,16 @@
 package com.teamsolply.solply.course.favoriteTown
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Icon

--- a/feature/course/src/main/java/com/teamsolply/solply/course/favoriteTown/FavoriteTownScreen.kt
+++ b/feature/course/src/main/java/com/teamsolply/solply/course/favoriteTown/FavoriteTownScreen.kt
@@ -57,7 +57,9 @@ fun FavoriteTownRoute(
         onNextClick = navigateToBack,
         onReturnToHomeClick = navigateToBack,
         onBackButtonClick = navigateToBack,
-        modifier = Modifier.padding(paddingValues)
+        modifier = Modifier
+            .background(SolplyTheme.colors.white)
+            .padding(paddingValues)
     )
 }
 
@@ -78,7 +80,6 @@ fun FavoriteTownScreen(
         modifier = modifier
             .fillMaxSize()
             .padding(top = 14.dp)
-            .background(SolplyTheme.colors.white)
     ) {
         FavoriteTownTopBar(
             onBackButtonClick = onBackButtonClick,

--- a/feature/course/src/main/java/com/teamsolply/solply/course/favoriteTown/FavoriteTownScreen.kt
+++ b/feature/course/src/main/java/com/teamsolply/solply/course/favoriteTown/FavoriteTownScreen.kt
@@ -1,20 +1,9 @@
 package com.teamsolply.solply.course.favoriteTown
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.material3.VerticalDivider
@@ -22,6 +11,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
@@ -33,6 +24,8 @@ import com.teamsolply.solply.course.favoriteTown.model.Region
 import com.teamsolply.solply.course.favoriteTown.model.TownLite
 import com.teamsolply.solply.designsystem.component.button.SolplyBasicButton
 import com.teamsolply.solply.designsystem.theme.SolplyTheme
+import com.teamsolply.solply.ui.extension.customClickable
+
 @Composable
 fun FavoriteTownRoute(
     paddingValues: PaddingValues,
@@ -76,6 +69,7 @@ fun FavoriteTownScreen(
         modifier = modifier
             .fillMaxSize()
             .padding(top = 14.dp)
+            .background(SolplyTheme.colors.white)
     ) {
         FavoriteTownTopBar(
             onBackButtonClick = onBackButtonClick,
@@ -86,6 +80,7 @@ fun FavoriteTownScreen(
             modifier = Modifier
                 .weight(1f)
                 .padding(top = 16.dp)
+                .background(SolplyTheme.colors.white)
         ) {
             LeftRegionPane(
                 regions = regions,
@@ -95,7 +90,7 @@ fun FavoriteTownScreen(
 
             VerticalDivider(
                 modifier = Modifier.fillMaxHeight(),
-                color = SolplyTheme.colors.gray200,
+                color = SolplyTheme.colors.gray100,
                 thickness = 1.dp
             )
 
@@ -131,26 +126,49 @@ private fun LeftRegionPane(
     selectedRegionId: Long?,
     onSelect: (Long) -> Unit
 ) {
+    val borderColor = SolplyTheme.colors.gray200
+
     LazyColumn(
         modifier = Modifier
             .width(124.dp)
             .fillMaxHeight()
-            .background(SolplyTheme.colors.gray200)
+            .background(SolplyTheme.colors.gray100)
     ) {
         items(regions, key = { it.id }) { region ->
             val selected = region.id == selectedRegionId
-            val bg = if (selected) Color.White else Color.Transparent
+            val bg = if (selected) SolplyTheme.colors.white else SolplyTheme.colors.gray100
             val textColor = if (selected) SolplyTheme.colors.black else SolplyTheme.colors.gray600
             val fontWeight = if (selected) FontWeight.SemiBold else FontWeight.Medium
 
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .height(56.dp)
+                    .height(46.dp)
                     .background(bg)
-                    .clickable { onSelect(region.id) }
-                    .padding(horizontal = 16.dp),
-                contentAlignment = Alignment.CenterStart
+                    .customClickable(rippleEnabled = false) {
+                        onSelect(region.id)
+                    }
+                    .drawBehind {
+                        val strokeWidth = 1.dp.toPx()
+                        val w = size.width
+                        val h = size.height
+
+                        if (region == regions.firstOrNull()) {
+                            drawLine(
+                                color = borderColor,
+                                start = Offset(0f, strokeWidth / 2),
+                                end = Offset(w, strokeWidth / 2),
+                                strokeWidth = strokeWidth
+                            )
+                        }
+                        drawLine(
+                            color = borderColor,
+                            start = Offset(0f, h - strokeWidth / 2),
+                            end = Offset(w, h - strokeWidth / 2),
+                            strokeWidth = strokeWidth
+                        )
+                    },
+                contentAlignment = Alignment.Center
             ) {
                 Text(
                     text = region.name,
@@ -158,12 +176,6 @@ private fun LeftRegionPane(
                     color = textColor
                 )
             }
-
-            HorizontalDivider(
-                modifier = Modifier.fillMaxWidth(),
-                thickness = 1.dp,
-                color = SolplyTheme.colors.gray200
-            )
         }
     }
 }
@@ -174,10 +186,12 @@ private fun RightTownPane(
     selectedTownId: Long?,
     onSelect: (Long) -> Unit
 ) {
+    val borderColor = SolplyTheme.colors.gray200
+
     LazyColumn(
         modifier = Modifier
-            .fillMaxSize()
-            .padding(start = 16.dp)
+            .fillMaxWidth()
+            .background(SolplyTheme.colors.white)
     ) {
         items(towns, key = { it.id }) { town ->
             val selected = town.id == selectedTownId
@@ -188,21 +202,45 @@ private fun RightTownPane(
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(46.dp)
-                    .clickable { onSelect(town.id) }
-                    .padding(horizontal = 16.dp),
+                    .customClickable(rippleEnabled = false) { onSelect(town.id) }
+                    .drawBehind {
+                        val strokeWidth = 1.dp.toPx()
+                        val w = size.width
+                        val h = size.height
+
+                        if (town == towns.firstOrNull()) {
+                            drawLine(
+                                color = borderColor,
+                                start = Offset(0f, strokeWidth / 2),
+                                end = Offset(w, strokeWidth / 2),
+                                strokeWidth = strokeWidth
+                            )
+                        }
+                        drawLine(
+                            color = borderColor,
+                            start = Offset(0f, h - strokeWidth / 2),
+                            end = Offset(w, h - strokeWidth / 2),
+                            strokeWidth = strokeWidth
+                        )
+                    },
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 Text(
                     text = town.name,
                     style = SolplyTheme.typography.body16M.copy(fontWeight = fontWeight),
                     color = textColor,
-                    modifier = Modifier.weight(1f)
+                    modifier = Modifier
+                        .weight(1f)
+                        .padding(start = 16.dp)
                 )
 
                 if (selected) {
                     Icon(
-                        painter = painterResource(id = com.teamsolply.solply.designsystem.R.drawable.ic_select_icon),
+                        painter = painterResource(
+                            id = com.teamsolply.solply.designsystem.R.drawable.ic_select_icon
+                        ),
                         contentDescription = "selected",
+                        modifier = Modifier.padding(end = 16.dp),
                         tint = Color.Unspecified
                     )
                 }

--- a/feature/oauth/src/main/java/com/teamsolply/solply/oauth/OauthScreen.kt
+++ b/feature/oauth/src/main/java/com/teamsolply/solply/oauth/OauthScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -142,7 +143,39 @@ fun OauthScreen(
             )
         }
 
-        Spacer(modifier = Modifier.height(100.dp))
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(52.dp)
+                .padding(start = 20.dp, end = 20.dp)
+                .background(
+                    color = SolplyTheme.colors.black,
+                    shape = RoundedCornerShape(12.dp)
+                )
+                .customClickable(
+                    rippleEnabled = false
+                ) {
+                    kakaoLoginClick()
+                },
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Start
+        ) {
+            Icon(
+                painter = painterResource(R.drawable.ic_apple_logo),
+                contentDescription = "kakao_logo",
+                tint = Color.Unspecified,
+                modifier = Modifier
+                    .padding(start = 16.dp, end = 12.dp, top = 12.dp, bottom = 12.dp)
+            )
+            Text(
+                text = stringResource(com.teamsolply.solply.oauth.R.string.apple_login),
+                style = SolplyTheme.typography.button16M,
+                color = SolplyTheme.colors.white
+            )
+        }
+        Spacer(modifier = Modifier.height(48.dp))
     }
 }
 


### PR DESCRIPTION
## 📌 PR 요약

🌱 작업한 내용
- FavoriteTownScreen ui 수정
- OauthScreen에 에플 로그인 버튼 추가

🌱 PR 포인트
-

## 📸 스크린샷
|스크린샷|
|:--:|
|<img width="300" src="https://github.com/user-attachments/assets/74221482-ee47-4083-8196-d91e4d5188c8" />|

## 📮 관련 이슈
- Resolved: #136 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 애플 로그인 버튼을 추가해 카카오와 함께 로그인 옵션을 확장했습니다(전체 너비, 둥근 사각 버튼, 아이콘 포함).

* 스타일
  * 즐겨찾는 동네 화면의 전체 배경과 좌·우 패널을 화이트로 정리해 시각적 일관성 개선.
  * 아이템별 상·하단 보더를 적용해 구분선을 자연스럽게 표시.
  * 좌측 지역 아이템 높이를 46dp로 낮추고 선택/비선택 색상 대비 개선.
  * 우측 동네 항목을 전체 너비로 확장하고 선택 아이콘·패딩 정리.
  * 클릭 리플 효과 제거 및 로그인 화면 간격 조정.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->